### PR TITLE
Add support for intel simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # pjproject-apple-platforms
 
 Script to build and install a xcframework that has headers and static libraries for all Apple platforms to be used in Xcode for development against pjproject.
+
+## How to use
+Before running you can customize the pjsip version used, modifying `PJSIP_VERSION` constant on `start.sh`
+
+Then you can run the script:
+
+```sh
+sh start.sh
+```
+
+> Disclaimer: Right now the xcframework is just generated correctly if the script is executed from an apple silicon mac.
+

--- a/start.sh
+++ b/start.sh
@@ -201,6 +201,21 @@ mkdir -p $OUT_SIM_ARM64
 # ar -csr $OUT_SIM_ARM64/libpjproject.a `find . -not -path "./pjsip-apps/*" -name "*.o"`
 libtool -static -o $OUT_SIM_ARM64/libpjproject.a `find . -not -path "./pjsip-apps/*" -not -path "$BUILD_DIR/*" -name "*.a"`
 
+#
+# build for simulator x86_64 & create lib
+#
+find . -not -path "./pjsip-apps/*" -not -path "$BUILD_DIR/*" -name "*.a" -exec rm {} \;
+IPHONESDK="$COMMAND_LINE_TOOLS_PATH/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk" DEVPATH="$COMMAND_LINE_TOOLS_PATH/Platforms/iPhoneSimulator.platform/Developer" ARCH="-arch x86_64" MIN_IOS="-mios-simulator-version-min=13" ./configure-iphone
+make dep && make clean
+CFLAGS="-Wno-macro-redefined -Wno-unused-variable -Wno-unused-function -Wno-deprecated-declarations -Wno-unused-private-field -Wno-unused-but-set-variable" make
+
+OUT_SIM_ARM64="$BUILD_DIR/sim_arm64"
+mkdir -p $OUT_SIM_X86_64
+# the Makefile is a little more selective about which .o files go into the lib
+# so let's use libtool instead of ar
+# ar -csr $OUT_SIM_X86_64/libpjproject.a `find . -not -path "./pjsip-apps/*" -name "*.o"`
+libtool -static -o $OUT_SIM_X86_64/libpjproject.a `find . -not -path "./pjsip-apps/*" -not -path "$BUILD_DIR/*" -name "*.a"`
+
 
 #
 # build for device arm64 & create lib

--- a/start.sh
+++ b/start.sh
@@ -209,7 +209,7 @@ IPHONESDK="$COMMAND_LINE_TOOLS_PATH/Platforms/iPhoneSimulator.platform/Developer
 make dep && make clean
 CFLAGS="-Wno-macro-redefined -Wno-unused-variable -Wno-unused-function -Wno-deprecated-declarations -Wno-unused-private-field -Wno-unused-but-set-variable" make
 
-OUT_SIM_ARM64="$BUILD_DIR/sim_arm64"
+OUT_SIM_X86_64="$BUILD_DIR/sim_x86_64"
 mkdir -p $OUT_SIM_X86_64
 # the Makefile is a little more selective about which .o files go into the lib
 # so let's use libtool instead of ar

--- a/start.sh
+++ b/start.sh
@@ -92,7 +92,7 @@ pjlibutil=${prefix}/libpjproject.xcframework/Headers/pjlib-util
 pjmedia=${prefix}/libpjproject.xcframework/Headers/pjmedia
 pjnath=${prefix}/libpjproject.xcframework/Headers/pjnath
 
-libdir=${prefix}/libpjproject.xcframework/ios-arm64-simulator
+libdir=${prefix}/libpjproject.xcframework/ios-arm64_x86_64-simulator
 
 Name: Cpjproject
 Version: ${PJSIP_VERSION}
@@ -268,6 +268,12 @@ OUT_MAC="$BUILD_DIR/mac"
 mkdir -p $OUT_MAC
 lipo -create $OUT_MAC_ARM64/libpjproject.a $OUT_MAC_X86_64/libpjproject.a -output $OUT_MAC/libpjproject.a
 
+#
+# create fat lib for the simulator
+#
+OUT_SIM="$BUILD_DIR/simulator"
+mkdir -p $OUT_SIM
+lipo -create $OUT_SIM_ARM64/libpjproject.a $OUT_SIM_X86_64/libpjproject.a -output $OUT_SIM/libpjproject.a
 
 #
 # collect headers & create xcframework
@@ -282,8 +288,8 @@ done
 XCFRAMEWORK="$BUILD_DIR/libpjproject.xcframework"
 rm -rf $XCFRAMEWORK
 xcodebuild -create-xcframework \
--library $OUT_SIM_ARM64/libpjproject.a \
 -library $OUT_DEV_ARM64/libpjproject.a \
+-library $OUT_SIM/libpjproject.a \
 -library $OUT_MAC/libpjproject.a \
 -output $XCFRAMEWORK
 

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # Oliver Epper <oliver.epper@gmail.com>
 
+export PJSIP_VERSION=2.12.1
+
 function clean {
 	echo "Cleaning"
 	rm -rf pjproject
@@ -49,7 +51,7 @@ pjnath=${prefix}/libpjproject.xcframework/Headers/pjnath
 libdir=${prefix}/libpjproject.xcframework/macos-arm64_x86_64
 
 Name: Cpjproject
-Version: 2.12
+Version: ${PJSIP_VERSION}
 Description: Multimedia communication library
 Libs: -L${libdir} -framework Network -framework Security -framework AudioToolbox -framework AVFoundation -framework CoreAudio -framework Foundation -lpjproject
 Cflags: -I${pjsip} -I${pjlib} -I${pjlibutil} -I${pjmedia} -I${pjnath}
@@ -71,7 +73,7 @@ pjnath=${prefix}/libpjproject.xcframework/Headers/pjnath
 libdir=${prefix}/libpjproject.xcframework/ios-arm64
 
 Name: Cpjproject
-Version: 2.12
+Version: ${PJSIP_VERSION}
 Description: Multimedia communication library
 Libs: -L${libdir} -framework Network -framework Security -framework AudioToolbox -framework AVFoundation -framework CoreAudio -framework Foundation -lpjproject
 Cflags: -I${pjsip} -I${pjlib} -I${pjlibutil} -I${pjmedia} -I${pjnath}
@@ -93,7 +95,7 @@ pjnath=${prefix}/libpjproject.xcframework/Headers/pjnath
 libdir=${prefix}/libpjproject.xcframework/ios-arm64-simulator
 
 Name: Cpjproject
-Version: 2.12
+Version: ${PJSIP_VERSION}
 Description: Multimedia communication library
 Libs: -L${libdir} -framework Network -framework Security -framework AudioToolbox -framework AVFoundation -framework CoreAudio -framework Foundation -lpjproject
 Cflags: -I${pjsip} -I${pjlib} -I${pjlibutil} -I${pjmedia} -I${pjnath}
@@ -113,7 +115,7 @@ pjmedia=${prefix}/libpjproject.xcframework/Headers/pjmedia
 pjnath=${prefix}/libpjproject.xcframework/Headers/pjnath
 
 Name: Cpjproject
-Version: 2.12
+Version: ${PJSIP_VERSION}
 Description: Multimedia communication library
 Libs: -framework Network -framework Security -framework AudioToolbox -framework AVFoundation -framework CoreAudio -framework Foundation -lpjproject
 Cflags: -I${pjsip} -I${pjlib} -I${pjlibutil} -I${pjmedia} -I${pjnath}
@@ -146,7 +148,7 @@ then
 	ln -sf start.sh install.sh
 fi
 
-git clone --depth 1 --branch 2.12 https://github.com/pjsip/pjproject # > /dev/null 2>&1
+git clone --depth 1 --branch $PJSIP_VERSION https://github.com/pjsip/pjproject # > /dev/null 2>&1
 cat << 'END' > pjproject/build_apple_platforms.sh
 #!/bin/sh
 


### PR DESCRIPTION
It's been a month since I offered my help, didn't have time til now 😅

**What's new?**

- Added PJSIP version as a constant that can be customized to specify version to compile.
- Upgraded PJSIP from 2.12 to 2.12.1
- Added x86_64 slice for iOS simulator & create fat lib (based code on the macOS fat lib)
- Updated README with instructions

**Important:**
- After generating it, tested successfully on both arm64 & intel (x86_64) sims, it was working (Feel free to test in any of your used platforms to see if anything broke)
- The script is not generating the final xcframework if it's executed from intel (Even without my changes, it says for example that x86_64 & arm64 slices for mac contains the same architecture) if you have any idea it will be cool to fix it, still isn't a deal breaker, for me it's fine just having a working xcframework even if it's generated on apple silicon.
- I didn't realized we need to install the brew package in order to run, I think because we need the pc files for `pkg-config` (I haven't used the tool before) and I was thinking if I was needing to change anything on those files, because I don't know where they are, still, no problem for me installing the brew package, it seems to be working, but if I need to change something, just point me in what to change // add